### PR TITLE
Fix navigation link, adjust tournament month handling, add calendar tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ bun dev
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
-You can start editing the page by modifying `pages/index.tsx`. The page auto-updates as you edit the file.
+You can start editing the page by modifying `src/pages/index.tsx`. The page auto-updates as you edit the file.
 
-[API routes](https://nextjs.org/docs/pages/building-your-application/routing/api-routes) can be accessed on [http://localhost:3000/api/hello](http://localhost:3000/api/hello). This endpoint can be edited in `pages/api/hello.ts`.
+[API routes](https://nextjs.org/docs/pages/building-your-application/routing/api-routes) can be accessed on [http://localhost:3000/api/hello](http://localhost:3000/api/hello). This endpoint can be edited in `src/pages/api/hello.ts`.
 
-The `pages/api` directory is mapped to `/api/*`. Files in this directory are treated as [API routes](https://nextjs.org/docs/pages/building-your-application/routing/api-routes) instead of React pages.
+The `src/pages/api` directory is mapped to `/api/*`. Files in this directory are treated as [API routes](https://nextjs.org/docs/pages/building-your-application/routing/api-routes) instead of React pages.
 
 This project uses [`next/font`](https://nextjs.org/docs/pages/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest run"
   },
   "dependencies": {
     "@tailwindcss/aspect-ratio": "^0.4.2",
@@ -29,6 +30,7 @@
     "eslint-config-next": "15.3.4",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.11",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^1.6.0"
   }
 }

--- a/src/__tests__/calendar.test.ts
+++ b/src/__tests__/calendar.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { getMonthData } from "../pages/calendar";
+
+describe("getMonthData", () => {
+  it("returns 28 days for February 2023", () => {
+    const data = getMonthData(2023, 1);
+    expect(data.filter(Boolean).length).toBe(28);
+  });
+
+  it("returns 29 days for February 2024", () => {
+    const data = getMonthData(2024, 1);
+    expect(data.filter(Boolean).length).toBe(29);
+  });
+
+  it("includes leading nulls so that January 2023 starts on Sunday", () => {
+    const data = getMonthData(2023, 0);
+    expect(data.slice(0, 6)).toEqual([null, null, null, null, null, null]);
+    expect(data[6]).toBe(1);
+  });
+});

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -12,7 +12,7 @@ const Layout = ({ children }: { children: ReactNode }) => {
           <li><Link href="/calendar">Calendar</Link></li>
           <li><Link href="/competitions">Competitions</Link></li>
           <li><Link href="/social">Social</Link></li>
-          <li><Link href="/donation">Donate</Link></li>
+          <li><Link href="/donate">Donate</Link></li>
           <li><Link href="/bio">Bio</Link></li>
         </ul>
       </nav>

--- a/src/pages/api/tournaments.ts
+++ b/src/pages/api/tournaments.ts
@@ -2,6 +2,15 @@ import fs from "fs";
 import path from "path";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+type Tournament = {
+  day: number;
+  month: number; // 0-basiert: Januar = 0, Dezember = 11
+  year: number;
+  title: string;
+  link: string;
+  image: string;
+};
+
 const filePath = path.join(process.cwd(), "data", "tournaments.json");
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -10,20 +19,22 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
       const data = fs.readFileSync(filePath, "utf-8");
       const tournaments = JSON.parse(data);
       res.status(200).json(tournaments);
-    } catch (err) {
+    } catch (error) {
+      console.error(error);
       res.status(500).json({ error: "Fehler beim Lesen der Turniere." });
     }
   } else if (req.method === "POST") {
     try {
-      // 🔧 Monat 1–12 wird zu 0–11 korrigiert
-      const tournaments = req.body.map((t: any) => ({
+      // 🔧 Der Client sendet Monate bereits 0-basiert (0–11)
+      const tournaments = (req.body as Tournament[]).map((t) => ({
         ...t,
-        month: t.month - 1,
+        month: t.month,
       }));
 
       fs.writeFileSync(filePath, JSON.stringify(tournaments, null, 2));
       res.status(200).json({ success: true });
-    } catch (err) {
+    } catch (error) {
+      console.error(error);
       res.status(500).json({ error: "Fehler beim Speichern der Turniere." });
     }
   } else {

--- a/src/pages/api/upload.ts
+++ b/src/pages/api/upload.ts
@@ -27,7 +27,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     }
 
     const file = files.file;
-    const filePath = Array.isArray(file) ? file[0]?.filepath : (file as any)?.filepath;
+    type FormidableFile = { filepath?: string };
+    const filePath = Array.isArray(file)
+      ? (file[0] as FormidableFile)?.filepath
+      : (file as FormidableFile)?.filepath;
     const fileName = filePath ? path.basename(filePath) : null;
 
     if (!fileName) {

--- a/src/pages/calendar.tsx
+++ b/src/pages/calendar.tsx
@@ -12,7 +12,7 @@ type Tournament = {
 
 const days = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 
-function getMonthData(year: number, month: number) {
+export function getMonthData(year: number, month: number) {
   const date = new Date(year, month, 1);
   const daysInMonth = new Date(year, month + 1, 0).getDate();
   const startDay = (date.getDay() + 6) % 7; // Montag = 0

--- a/src/pages/donate.tsx
+++ b/src/pages/donate.tsx
@@ -1,0 +1,10 @@
+import Layout from "@/components/Layout";
+
+export default function DonatePage() {
+  return (
+    <Layout>
+      <h2 className="text-xl font-bold">Donate</h2>
+      <p className="mt-4">Support DeeDeeChess by contributing to our efforts.</p>
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Summary
- Correct navigation bar donation link and add a Donate page
- Correct month handling in tournaments API and improve typing
- Expose calendar month helper and add unit tests
- Update README paths and type upload handler file path access
- Add vitest test script

## Testing
- `npm run lint`
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899fdd21404832f9138393d89f3b581